### PR TITLE
[ADD] movie crud & router

### DIFF
--- a/src/cinema/crud.py
+++ b/src/cinema/crud.py
@@ -14,7 +14,7 @@ async def get_cinemas(session: AsyncSession, skip: int = 0, limit: int = 100):
     return result.scalars().all()
 
 
-async def create_cinema(session: AsyncSession, cinema: CinemaCreate) -> CinemaRead:
+async def create_cinema(session: AsyncSession, cinema: CinemaCreate):
     db_cinema = Cinema(**cinema.model_dump())
     session.add(db_cinema)
     await session.commit()

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 from src.auth.router import auth_router
 from src.cinema.router import cinema_router
+from src.movie.router import movie_router
 
 app = FastAPI(title="PopcornBooking")
 
 app.include_router(auth_router)
 app.include_router(cinema_router)
+app.include_router(movie_router)

--- a/src/movie/crud.py
+++ b/src/movie/crud.py
@@ -1,0 +1,43 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from src.movie.models import Movie
+from src.movie.schemas import MovieCreate, MovieRead, MovieUpdate
+
+
+async def get_movie(session: AsyncSession, movie_id: int):
+    result = await session.execute(select(Movie).filter(Movie.id == movie_id))
+    return result.scalars().first()
+
+
+async def get_movies(session: AsyncSession, skip: int = 0, limit: int = 100):
+    result = await session.execute(select(Movie).offset(skip).limit(limit))
+    return result.scalars().all()
+
+
+async def create_movie(session: AsyncSession, movie: MovieCreate):
+    db_movie = Movie(**movie.model_dump())
+    session.add(db_movie)
+    await session.commit()
+    await session.refresh(db_movie)
+    return db_movie
+
+
+async def update_movie(db: AsyncSession, movie_id: int, movie: MovieUpdate):
+    result = await db.execute(select(Movie).filter(Movie.id == movie_id))
+    db_movie = result.scalars().first()
+    if db_movie:
+        update_data = movie.model_dump(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(db_movie, key, value)
+        await db.commit()
+        await db.refresh(db_movie)
+    return db_movie
+
+
+async def delete_movie(db: AsyncSession, movie_id: int):
+    result = await db.execute(select(Movie).filter(Movie.id == movie_id))
+    db_movie = result.scalars().first()
+    if db_movie:
+        await db.delete(db_movie)
+        await db.commit()
+    return db_movie

--- a/src/movie/models.py
+++ b/src/movie/models.py
@@ -12,6 +12,7 @@ class Movie(Base):
     description: Mapped[str]
     duration: Mapped[int]
 
-    session: Mapped["Session"] = relationship(
-        order_by="Session.id", back_populates="movie"
-    )
+    # session: Mapped["Session"] = relationship(
+    #     order_by="Session.id",
+    #     back_populates="movie",
+    # )

--- a/src/movie/router.py
+++ b/src/movie/router.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.movie import crud, schemas
+from src.database import get_async_session
+
+movie_router = APIRouter(prefix="/movie", tags=["Movie"])
+
+
+@movie_router.post("/", response_model=schemas.MovieRead)
+async def create_movie(
+    movie: schemas.MovieCreate, session: AsyncSession = Depends(get_async_session)
+):
+    return await crud.create_movie(session=session, movie=movie)
+
+
+@movie_router.get("/", response_model=list[schemas.MovieRead])
+async def read_movies(
+    skip: int = 0, limit: int = 100, session: AsyncSession = Depends(get_async_session)
+):
+    movies = await crud.get_movies(session, skip=skip, limit=limit)
+    return movies
+
+
+@movie_router.get("/{movie_id}", response_model=schemas.MovieRead)
+async def read_movie(movie_id: int, session: AsyncSession = Depends(get_async_session)):
+    db_movie = await crud.get_movie(session, movie_id=movie_id)
+    if db_movie is None:
+        raise HTTPException(
+            status_code=404, detail=f"Movie with id={movie_id} not found"
+        )
+    return db_movie
+
+
+@movie_router.put("/{movie_id}", response_model=schemas.MovieUpdate)
+async def update_movie(
+    movie_id: int,
+    movie: schemas.MovieUpdate,
+    session: AsyncSession = Depends(get_async_session),
+):
+    db_movie = await crud.update_movie(session, movie_id, movie)
+    if db_movie is None:
+        raise HTTPException(
+            status_code=404, detail=f"Movie with id={movie_id} not found"
+        )
+    return db_movie
+
+
+@movie_router.delete("/{movie_id}")
+async def delete_movie(
+    movie_id: int, session: AsyncSession = Depends(get_async_session)
+):
+    db_movie = await crud.delete_movie(session, movie_id)
+    if db_movie is None:
+        raise HTTPException(
+            status_code=404, detail=f"Movie with id={movie_id} not found"
+        )
+    return db_movie

--- a/src/movie/schemas.py
+++ b/src/movie/schemas.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class MovieBase(BaseModel):
     title: str
-    description: str | None
+    description: str
     duration: int
 
 
@@ -14,7 +14,7 @@ class MovieCreate(MovieBase):
 
 class MovieRead(MovieBase):
     id: int
-    session: list[dict]
+    # session: list[dict]
 
     class Config:
         from_attributes = True

--- a/src/session/models.py
+++ b/src/session/models.py
@@ -15,7 +15,7 @@ class Session(Base):
     cinema_id: Mapped[int] = mapped_column(ForeignKey("cinema.id"))
     start_time: Mapped[datetime]
 
-    movie: Mapped["Movie"] = relationship(back_populates="session")
-    booking: Mapped["Booking"] = relationship(
-        order_by="Booking.id", back_populates="session"
-    )
+    # movie: Mapped["Movie"] = relationship(back_populates="session")
+    # booking: Mapped["Booking"] = relationship(
+    #     order_by="Booking.id", back_populates="session"
+    # )


### PR DESCRIPTION
Implement CRUD operations and routing for Movie entity

- Add crud.py with asynchronous CRUD operations for Movie:
  * create_movie: Adds a new movie to the database.
  * get_movie: Retrieves a movie by its ID.
  * get_movies: Retrieves a list of all movies.
  * update_movie: Updates specified movie details.
  * delete_movie: Removes a movie from the database.

- Add router.py with API routes for Movie:
  * POST /movie: Create a new movie.
  * GET /movie/{id}: Get details of a specific movie.
  * GET /movie: List all movies.
  * PUT /movie/{id}: Update a movie.
  * DELETE /movie/{id}: Delete a movie.

- Utilize MovieRead and MovieCreate schemas for data validation and serialization.
- Ensure all database interactions are handled asynchronously to optimize performance.